### PR TITLE
rust: rustls prefer-post-quantum is a no-op against the ring provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ loose, mostly one paragraph each. no particular order.
 - [unix: `kill -0 <pid>` checks if a process exists without sending a real signal](unix/kill-zero.md)
 - [bash: `set -euo pipefail` catches unset vars, failed pipes, and unexpected exits](bash/set-euo.md)
 - [lua: `__index` metamethod enables prototype-style inheritance without copying methods](lua/metamethods.md)
+- [rust: `rustls`'s `prefer-post-quantum` feature is a no-op against the `ring` provider](rust/rustls-prefer-post-quantum-provider.md)
 
 ## closed proposals
 

--- a/rust/rustls-prefer-post-quantum-provider.md
+++ b/rust/rustls-prefer-post-quantum-provider.md
@@ -1,0 +1,37 @@
+# rustls `prefer-post-quantum` feature only does anything with `aws-lc-rs`
+
+If you want a rustls client that negotiates `X25519MLKEM768` (the IETF-WG-blessed post-quantum hybrid kex, codepoint `0x11ec`), the obvious thing is:
+
+```toml
+rustls = { version = "0.23", features = ["std", "tls12", "ring", "prefer-post-quantum"] }
+```
+
+This compiles fine. It also negotiates plain `X25519` against every server.
+
+## What's going on
+
+`rustls` 0.23 has two interchangeable crypto providers: `ring` and `aws-lc-rs`. Both are picked via cargo features. `prefer-post-quantum` is a separate feature that flips the kex-group ordering so the client offers `X25519MLKEM768` first.
+
+The trap: **`ring` does not implement ML-KEM**. The `prefer-post-quantum` flag has nothing to push to the front, so the client's kex offer is just `X25519, secp256r1, ...` and any server that supports the hybrid never gets the chance.
+
+`aws-lc-rs` does implement ML-KEM (it's based on AWS's post-quantum-friendly fork of BoringSSL).
+
+## Fix
+
+```toml
+rustls = { version = "0.23", default-features = false, features = ["std", "tls12", "aws-lc-rs", "prefer-post-quantum"] }
+```
+
+And install the provider:
+
+```rust
+let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+```
+
+Now `ClientConnection::negotiated_key_exchange_group()` actually returns `X25519MLKEM768` for any server that supports it (Cloudflare, Google, OpenAI, Anthropic, ...).
+
+## Tradeoff
+
+`aws-lc-rs` brings a sizeable C-via-cmake dependency and roughly doubles the release-binary size compared to `ring`. For a one-shot scanner that's fine; for a daemon that just needs classical X25519, `ring` stays smaller.
+
+This is one of those "the feature flag exists but it's a no-op against half the providers" cases that costs an hour to debug without a printed error.


### PR DESCRIPTION
new entry: `rust/rustls-prefer-post-quantum-provider.md`.

cost me an hour while building [pqfetch](https://github.com/f4rkh4d/pqfetch). the rustls feature flag `prefer-post-quantum` does what it says only when paired with the `aws-lc-rs` crypto provider. with `ring` (the rustls default in many configs), the flag is silently a no-op because ring does not implement ml-kem.

writing it up so the next person who hits this finds it on a search instead of staring at a wireshark dump for an hour.